### PR TITLE
fix gzdoom-9999 BUILD_NONFREE patch

### DIFF
--- a/games-fps/gzdoom/files/gzdoom-9999-Introduce-the-BUILD_NONFREE-option.patch
+++ b/games-fps/gzdoom/files/gzdoom-9999-Introduce-the-BUILD_NONFREE-option.patch
@@ -1,28 +1,21 @@
-commit b9d3095d3adc7a862034aae9547ed198fff97019
-Author: TheGreatMcPain <sixsupersonic@gmail.com>
-Date:   Sun Jan 17 15:06:27 2021 -0600
-
-    ../gzdoom-9999-Introduce-the-BUILD_NONFREE-option.patch
-
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 98116460a..f96c44838 100644
+index 156fa4ea9..3fba032f2 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -401,11 +401,15 @@ add_subdirectory( libraries/lzma )
+@@ -414,11 +414,14 @@ add_subdirectory( libraries/lzma )
  add_subdirectory( tools )
  add_subdirectory( libraries/gdtoa )
  add_subdirectory( wadsrc )
 -add_subdirectory( wadsrc_bm )
  add_subdirectory( wadsrc_lights )
 -add_subdirectory( wadsrc_extra )
- add_subdirectory( wadsrc_widescreen )
+ add_subdirectory( wadsrc_widepix )
  add_subdirectory( src )
 +option (BUILD_NONFREE "Build nonfree components" ON)
-+if( BUILD_NONFREE )
-+       add_subdirectory( wadsrc_bm )
-+       add_subdirectory( wadsrc_extra )
++if ( BUILD_NONFREE )
++    add_subdirectory( wadsrc_bm )
++    add_subdirectory( wadsrc_extra )
 +endif()
-+
  
  if( NOT CMAKE_CROSSCOMPILING )
  	export(TARGETS ${CROSS_EXPORTS} FILE "${CMAKE_BINARY_DIR}/ImportExecutables.cmake" )


### PR DESCRIPTION
Now, building gzdoom-9999 causes error because `CMakeLists.txt` (obviously) changed over time, and now patch is incorrect
This PR fixes this error (probably)